### PR TITLE
READMEの微修正とdocker-compose.yml の更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip3 install -r requirements.txt
 python3 app.py
 ```
 
-It will up at `http;//localhost:5000/`
+It will up at `http://localhost:5000/`
 
 ## with Batfish
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,10 @@ services:
       - "9996:9996"
       - "9997:9997"
   batfish-wrapper:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    image: batfish-wrapper
+    image: "ghcr.io/ool-mddo/batfish-wrapper:main" 
     environment:
       BATFISH_HOST: batfish
     ports:
       - "5000:5000"
-    volumes:
-      - .:/batfish-wrapper
     depends_on:
       - batfish


### PR DESCRIPTION
- http`;` → http`:`に修正
- 作成したbatfish-wrapper imageを使用するように修正